### PR TITLE
perf: smooth telestrator drawing + README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ A video replay tool for FRC teams, built with Electron, React, and Tailwind CSS.
 
 ## Features
 
-- Open and play local video files
+- Browse and play local video files with thumbnail previews
+- Open any video file directly or quickly load the most recent recording
 - Horizontal scroll to scrub through video
-- Vertical scroll to adjust playback speed
-- Touch screen drawing capabilities
+- Touch screen drawing / telestrator capabilities
 - Keyboard shortcuts for common actions
 
 ## Typical Workflow
@@ -15,18 +15,20 @@ A video replay tool for FRC teams, built with Electron, React, and Tailwind CSS.
 1. **Set Video Directory**
 
    - Use `Ctrl + D` to set the directory where your video files are stored
+   - The app defaults to `~/Downloads/replay` on startup
    - This directory will be remembered for future sessions
 
-2. **Open Latest Video**
+2. **Select a Video**
 
-   - Use `Ctrl + Shift + O` to open the most recent video file in the directory
-   - This is useful for quickly accessing the latest match recording
+   - Use `Ctrl + R` to open the video selector — a browsable list of all videos in the directory, each showing a thumbnail preview
+   - Use `Ctrl + O` to instantly open the most recent video file in the directory
+   - Use `Ctrl + Shift + O` to browse and open any specific file
 
 3. **Navigate to Relevant Section**
 
    - Use horizontal scroll to scrub through the video
    - For precise control, use `Ctrl + Shift + Left/Right Arrow` to jump in 15-second increments
-   - Adjust playback speed with vertical scroll or keyboard shortcuts
+   - Adjust playback speed with keyboard shortcuts
 
 4. **Analyze and Annotate**
    - Use touch screen or mouse to draw on the video
@@ -39,6 +41,7 @@ A video replay tool for FRC teams, built with Electron, React, and Tailwind CSS.
 
 - Node.js 20 or later
 - npm
+- ffmpeg (required for thumbnail generation)
 
 ### Setup
 
@@ -93,7 +96,7 @@ Built executables are available in two places:
 
 ### Video Controls
 
-- `Ctrl + Space`: Play/Pause
+- `Space`: Play/Pause
 - `Ctrl + Shift + Left Arrow`: Jump back 15 seconds
 - `Ctrl + Shift + Right Arrow`: Jump forward 15 seconds
 - `Ctrl + Shift + 1`: Set playback speed to 1x
@@ -112,24 +115,24 @@ Built executables are available in two places:
 
 ### File Operations
 
-- `Ctrl + O`: Open video file
-- `Ctrl + Shift + O`: Open specific video file
+- `Ctrl + O`: Open latest video in directory
+- `Ctrl + Shift + O`: Open a specific video file
+- `Ctrl + R`: Open video selector (browse all videos with thumbnails)
 - `Ctrl + D`: Set video directory
 - `F11` (Windows) or `Cmd + Ctrl + F` (Mac): Toggle full screen
+
+> **Mac users:** `Ctrl` shortcuts use `Cmd` instead (e.g., `Cmd + O`, `Cmd + D`).
 
 ## Scroll Interactions
 
 - **Horizontal Scroll**: Scrub through the video timeline
-
   - Scroll left to move backward in time
   - Scroll right to move forward in time
   - Scrolling speed is affected by current playback speed
 
-- **Vertical Scroll**: Adjust playback speed
-  - Scroll up to increase playback speed
-  - Scroll down to decrease playback speed
-  - Speed range: 0.1x to 4x
-  - Current speed is displayed in the bottom-right corner
+## How It Works
+
+The app runs a local HTTP server (port 3000) to serve video files from the configured directory. When the video selector is opened, thumbnails are automatically generated using ffmpeg and cached in a `thumbnails/` subfolder inside the video directory.
 
 ## Logitech MX Creative Console Configuration
 

--- a/src/components/Telestrator.tsx
+++ b/src/components/Telestrator.tsx
@@ -1,84 +1,99 @@
 import { useDrawingStore } from '../stores/useDrawingStore';
-import { useState, useRef, useEffect, useCallback, memo } from 'react';
+import { useRef, useEffect, useCallback, memo } from 'react';
+
+function redrawStrokes(ctx: CanvasRenderingContext2D, drawings: { points: { x: number; y: number }[]; color: string }[]) {
+  ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+  for (const drawing of drawings) {
+    if (drawing.points.length < 2) continue;
+    ctx.strokeStyle = drawing.color;
+    ctx.lineWidth = 7;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.beginPath();
+    ctx.moveTo(drawing.points[0].x, drawing.points[0].y);
+    for (let i = 1; i < drawing.points.length; i++) {
+      ctx.lineTo(drawing.points[i].x, drawing.points[i].y);
+    }
+    ctx.stroke();
+  }
+}
 
 export const Telestrator = memo(() => {
-  const { drawings, setDrawings, lineColor } = useDrawingStore();
-  const [isDrawing, setIsDrawing] = useState(false);
+  const { drawings, addDrawing, lineColor } = useDrawingStore();
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  // Active stroke lives only in refs — no state updates during drawing
+  const activeStrokeRef = useRef<{ x: number; y: number }[]>([]);
+  const activeColorRef = useRef<string>('yellow');
+  const isDrawingRef = useRef(false);
 
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
-
-    // Set canvas size to match window
     const resizeCanvas = () => {
       canvas.width = window.innerWidth;
       canvas.height = window.innerHeight;
+      // Redraw after resize since resizing clears the canvas
+      const ctx = canvas.getContext('2d');
+      if (ctx) redrawStrokes(ctx, drawings);
     };
 
     resizeCanvas();
     window.addEventListener('resize', resizeCanvas);
-
     return () => window.removeEventListener('resize', resizeCanvas);
   }, []);
 
+  // Redraw committed strokes whenever the store changes (clear, new stroke added, etc.)
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
-
-    // Clear canvas
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-
-    for (const drawing of drawings) {
-      // Draw lines
-      ctx.strokeStyle = drawing.color;
-      ctx.lineWidth = 7;
-      ctx.lineCap = 'round';
-      ctx.lineJoin = 'round';
-
-      if (drawing.points.length > 1) {
-        ctx.beginPath();
-        ctx.moveTo(drawing.points[0].x, drawing.points[0].y);
-        for (let i = 1; i < drawing.points.length; i++) {
-          ctx.lineTo(drawing.points[i].x, drawing.points[i].y);
-        }
-        ctx.stroke();
-      }
-    }
+    redrawStrokes(ctx, drawings);
   }, [drawings]);
 
   const handlePointerDown = useCallback(
     (e: React.PointerEvent) => {
-      setIsDrawing(true);
-      setDrawings([...drawings, { points: [{ x: e.clientX, y: e.clientY }], color: lineColor }]);
+      isDrawingRef.current = true;
+      activeColorRef.current = lineColor;
+      activeStrokeRef.current = [{ x: e.clientX, y: e.clientY }];
     },
-    [drawings, lineColor, setDrawings]
+    [lineColor]
   );
 
-  const handlePointerMove = useCallback(
-    (e: React.PointerEvent) => {
-      if (!isDrawing) return;
-      const lastDrawing = drawings[drawings.length - 1];
-      setDrawings([
-        ...drawings.slice(0, -1),
-        {
-          ...lastDrawing,
-          points: [...lastDrawing.points, { x: e.clientX, y: e.clientY }],
-        },
-      ]);
-    },
-    [isDrawing, drawings, setDrawings]
-  );
+  const handlePointerMove = useCallback((e: React.PointerEvent) => {
+    if (!isDrawingRef.current) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const points = activeStrokeRef.current;
+    const prev = points[points.length - 1];
+    const next = { x: e.clientX, y: e.clientY };
+    points.push(next);
+
+    // Draw only the new segment — no full redraw
+    ctx.strokeStyle = activeColorRef.current;
+    ctx.lineWidth = 7;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.beginPath();
+    ctx.moveTo(prev.x, prev.y);
+    ctx.lineTo(next.x, next.y);
+    ctx.stroke();
+  }, []);
 
   const handlePointerUp = useCallback(() => {
-    setIsDrawing(false);
-  }, []);
+    if (!isDrawingRef.current) return;
+    isDrawingRef.current = false;
+    const points = activeStrokeRef.current;
+    if (points.length > 1) {
+      // Commit completed stroke to the store
+      addDrawing({ points, color: activeColorRef.current });
+    }
+    activeStrokeRef.current = [];
+  }, [addDrawing]);
 
   return (
     <canvas

--- a/src/stores/useDrawingStore.ts
+++ b/src/stores/useDrawingStore.ts
@@ -15,7 +15,7 @@ export interface Drawing {
 interface DrawingState {
   drawings: Drawing[];
   lineColor: LineColor;
-  setDrawings: (drawings: Drawing[]) => void;
+  addDrawing: (drawing: Drawing) => void;
   setLineColor: (color: LineColor) => void;
   clearDrawings: () => void;
 }
@@ -23,7 +23,7 @@ interface DrawingState {
 export const useDrawingStore = create<DrawingState>((set) => ({
   drawings: [],
   lineColor: 'yellow',
-  setDrawings: (drawings) => set({ drawings }),
+  addDrawing: (drawing) => set((state) => ({ drawings: [...state.drawings, drawing] })),
   setLineColor: (color) => set({ lineColor: color }),
   clearDrawings: () => set({ drawings: [] }),
 }));


### PR DESCRIPTION
## Summary

- **Telestrator performance**: Eliminated O(n²) full-canvas redraws during drawing. Active strokes now render incrementally via direct `ctx` calls (one segment per pointer move, zero state updates). Completed strokes are committed to the store on `pointerUp`, which triggers a single full redraw. Drawing should now feel smooth regardless of stroke count.
- **Store cleanup**: Replaced `setDrawings` with `addDrawing` to make the intended mutation explicit and avoid passing full arrays around.
- **README accuracy**: Fixed incorrect keyboard shortcuts (`Space` not `Ctrl+Space`, added missing `Ctrl+R` video selector), removed vertical-scroll speed control that no longer exists, added default video directory and ffmpeg prerequisite.

## Test plan

- [ ] Draw multiple strokes — should feel immediate with no lag
- [ ] Clear drawings with `Escape` — canvas should clear cleanly
- [ ] Resize window while strokes are on screen — strokes should redraw correctly
- [ ] Change color mid-session and draw — new strokes use new color, old strokes keep their color
- [ ] Open video selector with `Ctrl+R`, open latest with `Ctrl+O`

🤖 Generated with [Claude Code](https://claude.com/claude-code)