### PR TITLE
ci: add macOS builds, fix broken release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,60 +1,68 @@
-name: Build and Release
+name: Build
 
 on:
   push:
     branches: [main]
-  release:
-    types: [created]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
 
 jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
+      - name: Install Linux build dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get install -y rpm fakeroot
+
       - name: Install dependencies
-        run: |
-          npm ci
-          npm install -D @types/node ts-node
+        run: npm ci
 
-      - name: Build
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          export NODE_OPTIONS=--max_old_space_size=4096
-          npx electron-forge make
+      - name: Make (Linux / macOS)
+        if: matrix.os != 'windows-latest'
+        run: npx electron-forge make
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
 
-      - name: Build Windows
+      - name: Make (Windows)
         if: matrix.os == 'windows-latest'
-        run: |
-          $env:NODE_OPTIONS="--max_old_space_size=4096"
-          npx electron-forge make --config=forge.config.js
+        run: npx electron-forge make --config=forge.config.js
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
 
-      - name: List build artifacts (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: ls -R out/
-
-      - name: List build artifacts (Windows)
-        if: matrix.os == 'windows-latest'
-        run: Get-ChildItem -Path out -Recurse -File | Select-Object FullName
-
-      - name: Upload artifacts
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: replayhelper-${{ matrix.os }}
           path: |
             out/make/**/*.deb
+            out/make/**/*.rpm
             out/make/**/*.exe
             out/make/**/*.zip
-            out/make/**/*.AppImage
             out/make/**/*.dmg
             config/logitech/**
+
+      - name: Attach to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            out/make/**/*.deb
+            out/make/**/*.rpm
+            out/make/**/*.exe
+            out/make/**/*.zip
+            out/make/**/*.dmg
+            config/logitech/**
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,9 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4.4.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -42,7 +42,7 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=4096
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: replayhelper-${{ matrix.os }}
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,22 +1,11 @@
-name: Create Release
-
+# Release handling has been consolidated into build.yml.
+# Pushing a v* tag triggers a build on all platforms and automatically
+# attaches the installers to a GitHub Release.
+name: Release (deprecated)
 on:
-  push:
-    tags:
-      - 'v*'
-
+  workflow_dispatch:
 jobs:
-  create-release:
+  info:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            out/make/*.deb
-            out/make/*.exe
-            out/make/*.zip
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: echo "Release handling has moved to build.yml. Push a v* tag to trigger a release build."


### PR DESCRIPTION
## Summary

- Adds macOS runner — produces a `.zip` installer for Mac
- Installs `rpm` and `fakeroot` on Ubuntu so `MakerRpm` and `MakerDeb` don't fail
- Fixes the broken `release.yml` — it was creating a release but never building anything, so no files were ever attached
- Consolidates into one `build.yml`: CI builds on push/PR, artifacts uploaded on every run, installers attached to GitHub Release on `v*` tag push
- Deprecates `release.yml` (manual trigger only, with a note pointing to `build.yml`)

## Test plan

- [ ] Open this PR — the `Build` workflow should trigger and produce artifacts for all three platforms
- [ ] Check the Actions tab and download the artifacts to verify installers are valid
- [ ] After merge, push a `v*` tag and confirm a GitHub Release is created with all installers attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)